### PR TITLE
Fixing the typo error in the Redis section of the .env.example file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ EMAIL_FROM=from@example.com
 EMAIL_REPLY_TO=info@example.com
 
 ## REDIS
-REDIS_HOST=tcp
+REDIS_SCHEME=tcp
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 


### PR DESCRIPTION
There is a typo error in the REDIS section of your .env.example file, where you are overwriting the REDIS_HOST variable with "tcp" and then with "127.0.0.1".

The REDIS_HOST variable has been renamed to REDIS_SCHEME, indicating the connection scheme for Redis. The value "tcp" is used for the connection scheme.